### PR TITLE
Use 17 digits of precision with Double.ToString

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -1589,6 +1589,14 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual("{\"Positions\":[57.72,60.44,63.44,66.81,70.45],\"Loads\":[23284.0,23225.0,23062.0,22846.0,22594.0],\"Gain\":12345.679}", json);
         }
 
+        [Test]
+        public void DoubleRoundTrip()
+        {
+            var x = 0.1 + 0.2;
+            var y = JsonConvert.DeserializeObject<double>(JsonConvert.SerializeObject(x));
+            Assert.AreEqual(x, y);
+        }
+
         public class Measurements
         {
             [JsonProperty(ItemConverterType = typeof(RoundingJsonConverter))]

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -292,7 +292,7 @@ namespace Newtonsoft.Json
         /// <returns>A JSON string representation of the <see cref="Double"/>.</returns>
         public static string ToString(double value)
         {
-            return EnsureDecimalPlace(value, value.ToString("R", CultureInfo.InvariantCulture));
+            return EnsureDecimalPlace(value, value.ToString("G17", CultureInfo.InvariantCulture));
         }
 
         internal static string ToString(double value, FloatFormatHandling floatFormatHandling, char quoteChar, bool nullable)


### PR DESCRIPTION
Using 15 digits ("R") leads to failure of roundtrip serialization/deserialization.

See also https://learn.microsoft.com/en-us/dotnet/api/system.double.tostring

Another example is 0.6822871999174